### PR TITLE
fix: 警告UI関連の2つの問題を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -1448,6 +1448,12 @@ document.addEventListener('DOMContentLoaded', function() {
         // 翻訳品質警告の履歴もクリア
         translationQualityWarningHistory.clear();
 
+        // 翻訳品質警告の要素も削除
+        const warningElement = document.getElementById('translationQualityWarning');
+        if (warningElement) {
+            warningElement.remove();
+        }
+
         // 再生ボタンを無効化
         updateTranslationBoxState(false);
 
@@ -1853,6 +1859,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 翻訳ボックスに追加
         targetElement.appendChild(warning);
+
+        // 警告要素全体のクリックイベントを処理（TTS再生イベントの伝播を防止）
+        warning.addEventListener('click', (e) => {
+            e.stopPropagation();
+        });
 
         // 再翻訳ボタンのイベントリスナー
         document.getElementById('retryTranslationBtn').addEventListener('click', (e) => {


### PR DESCRIPTION
## 修正内容

### 1. 警告要素全体にstopPropagation()を適用（問題1）
- **問題**: 警告のテキストや背景をクリックするとTTS再生が誤って実行される
- **原因**: ボタンにはstopPropagation()があるが、警告要素自体にはない
- **修正**: 警告要素全体にclickイベントリスナーを追加し、stopPropagation()を実行
- **効果**: 警告のどこをクリックしてもTTS再生は実行されなくなる

### 2. resetContent()で警告要素を削除（問題2）
- **問題**: リセット時に警告履歴はクリアされるが、警告要素（DOM）は削除されない
- **原因**: translatedText.textContent = ''でテキストは消えるが、警告要素は残る
- **修正**: resetContent()で警告要素をgetElementByIdで取得し、存在する場合は削除
- **効果**: リセット後に古い警告が画面に残らなくなる

## 自己チェック結果の対応
自己チェックで発見した重大な問題2件を修正
- ✅ 問題1: 警告要素クリック時のTTS誤再生を防止
- ✅ 問題2: リセット時の警告要素残存を解消

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation quality warning interactions that were inadvertently triggering unintended actions. The warning now properly handles user interactions (dismiss and retry) without affecting other features like audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->